### PR TITLE
Add redeployment protection after estop

### DIFF
--- a/solana-verifier/README.md
+++ b/solana-verifier/README.md
@@ -80,7 +80,7 @@ yarn run accept  # Run on new owner's machine
 
 2. Add Verifier:
 ```bash
-VERIFIER_ADDRESS=<address> yarn run add
+VERIFIER_ADDRESS=<address> SELECTOR=<selector-hex> yarn run add
 ```
 
 3. Emergency Stop:

--- a/solana-verifier/programs/verifier_router/src/state/mod.rs
+++ b/solana-verifier/programs/verifier_router/src/state/mod.rs
@@ -41,8 +41,10 @@ pub struct VerifierRouter {
 /// # Fields
 /// * `selector` - Unique identifier for this verifier entry
 /// * `verifier` - Public key of the verifier program
+/// * `estopped` - Boolean flag indicating if the verifier has been emergency stopped
 #[account]
 pub struct VerifierEntry {
     pub selector: Selector,
     pub verifier: Pubkey,
+    pub estopped: bool,
 }

--- a/solana-verifier/scripts/addVerifier.ts
+++ b/solana-verifier/scripts/addVerifier.ts
@@ -47,6 +47,7 @@ import {
   getVerifierAddress,
   getRouterPda,
   createLogger,
+  getSelector,
 } from "./utils/utils";
 import { addVerifier } from "./utils/addVerifier";
 
@@ -57,6 +58,7 @@ async function runAddVerifier() {
   const routerAddress = getRouterAddress();
   const deployer = await getLocalKeypair();
   const owner = await getTransactionSigner();
+  const selector = getSelector();
 
   logger.info(
     `Using Router: ${routerAddress}, adding verifier ${verifierAddress}`
@@ -82,7 +84,8 @@ async function runAddVerifier() {
     rpc.rpc_subscription,
     verifierAddress,
     routerAddress,
-    owner
+    owner,
+    selector
   );
 
   logger.info("Verifier was successfully added to the router");

--- a/solana-verifier/scripts/estop.ts
+++ b/solana-verifier/scripts/estop.ts
@@ -48,6 +48,7 @@ import {
   createRpc,
   getRouterAddress,
   getTransactionSigner,
+  parseHex,
 } from "./utils/utils";
 import * as readline from "readline/promises";
 const rl = readline.createInterface({
@@ -58,15 +59,18 @@ import { estopByOwner } from "./utils/estop";
 
 const logger = createLogger();
 
-async function collectUserInput(): Promise<number> {
+async function collectUserInput(): Promise<Uint8Array> {
   console.log(
     "Script to call Estop initiated, answer the following questions to continue:"
   );
-  const input = Number(await rl.question("Enter Verifier selector (u32): "));
-  const verify = Number(
-    await rl.question(`Reenter verifier selector to confirm: `)
+  const selector = parseHex(await rl.question("Enter Verifier selector as hex string: "), 4);
+  const verify = parseHex(
+    await rl.question(`Reenter verifier selector to confirm: `), 4
   );
-  if (input !== verify) {
+  if (
+    selector.length !== verify.length ||
+    !selector.every((value, index) => value === verify[index])
+  ) {
     logger.error("Inputs did not match, Exiting.");
     process.exit(1);
   }
@@ -78,7 +82,7 @@ async function collectUserInput(): Promise<number> {
     process.exit(1);
   }
   rl.close();
-  return input;
+  return selector;
 }
 
 async function run_estop() {

--- a/solana-verifier/scripts/utils/estop.ts
+++ b/solana-verifier/scripts/utils/estop.ts
@@ -52,13 +52,13 @@ export async function estopByOwner(
   rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>,
   routerAddress: Address<string>,
   owner: TransactionSigner,
-  selector: number
+  selector: Uint8Array,
 ): Promise<void> {
   logger.warn(
     "EMERGENCY STOP HAS BEEN STARTED, THIS IS IRREVERSABLE...Program Will sleep for 5 seconds Kill program immediatly if not intentional, attempting to terminate a verifier!"
   );
   logger.info(
-    `Emeregency Stop attempting to stop verifier with Selector: ${selector} on router ${routerAddress}`
+    `Emeregency Stop attempting to stop verifier with Selector: 0x${Buffer.from(selector).toString("hex")} on router ${routerAddress}`
   );
 
   await sleep(5000); // Sleep for 5 seconds in case this was an accident

--- a/solana-verifier/scripts/utils/utils.ts
+++ b/solana-verifier/scripts/utils/utils.ts
@@ -673,7 +673,7 @@ function parseBoolean(value: string): boolean {
  * @param value - String to parse
  * @returns Parsed value
  */
-function parseHex(value: string, length: number): Uint8Array {
+export function parseHex(value: string, length: number): Uint8Array {
   // Normalize: remove optional "0x" prefix
   if (value.startsWith("0x") || value.startsWith("0X")) {
     value = value.slice(2);

--- a/solana-verifier/scripts/verify-router/accounts/verifierEntry.ts
+++ b/solana-verifier/scripts/verify-router/accounts/verifierEntry.ts
@@ -17,6 +17,8 @@ import {
   fixEncoderSize,
   getAddressDecoder,
   getAddressEncoder,
+  getBooleanDecoder,
+  getBooleanEncoder,
   getBytesDecoder,
   getBytesEncoder,
   getStructDecoder,
@@ -49,11 +51,13 @@ export type VerifierEntry = {
   discriminator: ReadonlyUint8Array;
   selector: ReadonlyUint8Array;
   verifier: Address;
+  estopped: boolean;
 };
 
 export type VerifierEntryArgs = {
   selector: ReadonlyUint8Array;
   verifier: Address;
+  estopped: boolean;
 };
 
 export function getVerifierEntryEncoder(): FixedSizeEncoder<VerifierEntryArgs> {
@@ -62,6 +66,7 @@ export function getVerifierEntryEncoder(): FixedSizeEncoder<VerifierEntryArgs> {
       ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
       ['selector', fixEncoderSize(getBytesEncoder(), 4)],
       ['verifier', getAddressEncoder()],
+      ['estopped', getBooleanEncoder()],
     ]),
     (value) => ({ ...value, discriminator: VERIFIER_ENTRY_DISCRIMINATOR })
   );
@@ -72,6 +77,7 @@ export function getVerifierEntryDecoder(): FixedSizeDecoder<VerifierEntry> {
     ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
     ['selector', fixDecoderSize(getBytesDecoder(), 4)],
     ['verifier', getAddressDecoder()],
+    ['estopped', getBooleanDecoder()],
   ]);
 }
 
@@ -140,5 +146,5 @@ export async function fetchAllMaybeVerifierEntry(
 }
 
 export function getVerifierEntrySize(): number {
-  return 44;
+  return 45;
 }

--- a/solana-verifier/tests/router-verifier.ts
+++ b/solana-verifier/tests/router-verifier.ts
@@ -17,7 +17,6 @@ import {
   getEmergencyStopInstruction,
   fetchVerifierEntry,
   getVerifyInstruction,
-  fetchMaybeVerifierEntry,
 } from "../scripts/verify-router";
 import {
   sendTransaction,
@@ -300,12 +299,9 @@ describe("verifier-router", () => {
       verifierProgramData: badVerifierProgramDataAddress,
     });
 
-    let routerAccount = await fetchVerifierRouter(rpc, routerAddress);
 
     // We must do these sequentially so that we don't hit a race condition on selector numbers
     await sendTx(addGrothInstruction);
-
-    routerAccount = await fetchVerifierRouter(rpc, routerAddress);
 
     const grothAccount = await fetchVerifierEntry(rpc, grothPDAAddress);
     expect(grothAccount.data.selector).to.deep.equal(GROTH16_SELECTOR);
@@ -320,8 +316,6 @@ describe("verifier-router", () => {
     expect(badAccount.data.verifier).to.equal(
       TEST_BAD_VERIFIER_PROGRAM_ADDRESS
     );
-
-    routerAccount = await fetchVerifierRouter(rpc, routerAddress);
   });
 
   it("should allow a user to submit a valid proof to the verifier", async () => {
@@ -365,7 +359,7 @@ describe("verifier-router", () => {
     piA[0] = 42;
 
     // Test Proof for the Test Bad Verifier
-    let badProof: Proof = {
+    const badProof: Proof = {
       piA, // Non-Empty 64 Byte array
       piB: new Array(128), // Empty 128 byte array
       piC: new Uint8Array(64), // Empty 64 byte array
@@ -373,12 +367,10 @@ describe("verifier-router", () => {
 
     const estopProofInstruction = getEmergencyStopWithProofInstruction({
       authority: notOwner,
-      bpfLoaderUpgradableProgram: SOLANA_LOADER_V3_PROGRAM_PROGRAM_ADDRESS,
       proof: badProof,
       router: routerAddress,
       selector: TEST_BAD_SELECTOR,
       verifierEntry: badVerifierPDAAddress,
-      verifierProgramData: badVerifierProgramDataAddress,
       verifierProgram: TEST_BAD_VERIFIER_PROGRAM_ADDRESS,
     });
 
@@ -392,11 +384,9 @@ describe("verifier-router", () => {
   it("should not allow someone other then owner to call estop by owner", async () => {
     const estopProofInstruction = getEmergencyStopInstruction({
       authority: notOwner,
-      bpfLoaderUpgradableProgram: SOLANA_LOADER_V3_PROGRAM_PROGRAM_ADDRESS,
       router: routerAddress,
       selector: TEST_BAD_SELECTOR,
       verifierEntry: badVerifierPDAAddress,
-      verifierProgramData: badVerifierProgramDataAddress,
       verifierProgram: TEST_BAD_VERIFIER_PROGRAM_ADDRESS,
     });
 
@@ -406,12 +396,10 @@ describe("verifier-router", () => {
   it("should allow any user to call e-stop if they have proof the verifier is broken", async () => {
     const estopProofInstruction = getEmergencyStopWithProofInstruction({
       authority: notOwner,
-      bpfLoaderUpgradableProgram: SOLANA_LOADER_V3_PROGRAM_PROGRAM_ADDRESS,
       proof: emptyProof,
       router: routerAddress,
       selector: TEST_BAD_SELECTOR,
       verifierEntry: badVerifierPDAAddress,
-      verifierProgramData: badVerifierProgramDataAddress,
       verifierProgram: TEST_BAD_VERIFIER_PROGRAM_ADDRESS,
     });
 
@@ -427,11 +415,9 @@ describe("verifier-router", () => {
   it("Should allow an owner to call estop", async () => {
     const estopProofInstruction = getEmergencyStopInstruction({
       authority: owner,
-      bpfLoaderUpgradableProgram: SOLANA_LOADER_V3_PROGRAM_PROGRAM_ADDRESS,
       router: routerAddress,
       selector: GROTH16_SELECTOR,
       verifierEntry: grothPDAAddress,
-      verifierProgramData: grothProgramDataAddress,
       verifierProgram: GROTH16_VERIFIER_PROGRAM_ADDRESS,
     });
 

--- a/solana-verifier/tests/router-verifier.ts
+++ b/solana-verifier/tests/router-verifier.ts
@@ -417,13 +417,11 @@ describe("verifier-router", () => {
 
     await sendTx(estopProofInstruction);
 
-    const verifierEntry = await fetchMaybeVerifierEntry(
+    const verifierEntry = await fetchVerifierEntry(
       rpc,
       badVerifierPDAAddress
     );
-    expect(verifierEntry.exists).to.equal(false);
-
-    const routerAccount = await fetchVerifierRouter(rpc, routerAddress);
+    expect(verifierEntry.data.estopped).to.equal(true);
   });
 
   it("Should allow an owner to call estop", async () => {
@@ -439,10 +437,8 @@ describe("verifier-router", () => {
 
     await sendTx(estopProofInstruction);
 
-    const verifierEntry = await fetchMaybeVerifierEntry(rpc, grothPDAAddress);
-    expect(verifierEntry.exists).to.equal(false);
-
-    const routerAccount = await fetchVerifierRouter(rpc, routerAddress);
+    const verifierEntry = await fetchVerifierEntry(rpc, grothPDAAddress);
+    expect(verifierEntry.data.estopped).to.equal(true);
   });
 
   it("should not allow a user to submit a valid proof to the verifier after e-stop was called on it", async () => {
@@ -458,6 +454,6 @@ describe("verifier-router", () => {
       journalDigest: emptyJournalDigest,
     });
 
-    await expectError(sendTx(verifyInstruction), "AccountNotInitialized");
+    await expectError(sendTx(verifyInstruction), "SelectorDeactivated");
   });
 });


### PR DESCRIPTION
Prior to this the Groth16 verifier programs were removed on an estop and an incremented nonce used to ensure no selector reuse.

After switching to hash based selectors it was possible for the owner to redeploy estopped verifiers to the old addresses (and selectors) at a later date. This is not part of the security mode.

- Adds a new field to Verifier accounts `estopped`
- Sets this to true on an estop rather than deleting the account
- This is checked by the router prior to routing a call